### PR TITLE
Fix PHP 8+ compatibility in comments.php

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -14,8 +14,11 @@ endif;
 <div id="comments" class="commentwrap">
 	<div class="comments-wrapper">
 		
-		<?php if ( have_comments() || comments_open() ) :		
-		
+		<?php if ( have_comments() || comments_open() ) :
+
+			$commenter = wp_get_current_commenter();
+			global $user_identity;
+
 			$custom_comment_form = array( 
 				'fields' => apply_filters( 'comment_form_default_fields', 
 					array(


### PR DESCRIPTION
Initialize $commenter via wp_get_current_commenter() and declare
$user_identity as global before use. These undefined variables cause
fatal errors in PHP 8.0+ when accessing array offsets on null.

https://claude.ai/code/session_01C9sq4vf9kdNTNPbECLmwEa